### PR TITLE
fix: check property exists before accessing it

### DIFF
--- a/lib/rules/no-env-in-context.js
+++ b/lib/rules/no-env-in-context.js
@@ -48,7 +48,7 @@ module.exports = {
           if (param) {
             if (param.type === 'ObjectPattern') {
               for (const prop of param.properties) {
-                if (ENV.includes(prop.key.name)) {
+                if (prop.key && prop.key.name && ENV.includes(prop.key.name)) {
                   context.report({
                     node: prop,
                     messageId: 'noEnv',


### PR DESCRIPTION
I have a particular case where this linting error is causing my whole app to crash:
<img width="1065" alt="Screenshot 2020-04-24 at 14 34 00" src="https://user-images.githubusercontent.com/810579/80208453-ecf52200-8638-11ea-8572-69bba8be8dc9.png">

After some debugging, it appears that the rule is trying to access a name property on an object that doesn't exist. It seems that the property it's trying to test isn't a normal object property, it's a babel rest spread operator, hence there's no `key`:
<img width="489" alt="Screenshot 2020-04-24 at 14 34 41" src="https://user-images.githubusercontent.com/810579/80208560-2594fb80-8639-11ea-960f-14d0ff8cc7c2.png">
