### PR TITLE
fix: disallow `process.browser` in `no-env-in-hooks`

### DIFF
--- a/docs/rules/no-env-in-hooks.md
+++ b/docs/rules/no-env-in-hooks.md
@@ -1,12 +1,12 @@
 # nuxt/no-env-in-hooks
 
-> Disallow `process.server` and `process.client` in the following lifecycle hooks: `beforeMount`, `mounted`, `beforeUpdate`, `updated`, `activated`, `deactivated`, `beforeDestroy` and `destroyed`.
+> Disallow `process.server`, `process.client` and `process.browser` in the following lifecycle hooks: `beforeMount`, `mounted`, `beforeUpdate`, `updated`, `activated`, `deactivated`, `beforeDestroy` and `destroyed`.
 
 - :gear: This rule is included in `"plugin:nuxt/base"`.
 
 ## Rule Details
 
-This rule is for preventing using `process.server/process.client` in client only Vue lifecycle hooks since they're only executed in client side.
+This rule is for preventing using `process.server`/`process.client`/`process.browser` in client only Vue lifecycle hooks since they're only executed in client side.
 
 Examples of **incorrect** code for this rule:
 
@@ -20,6 +20,11 @@ export default {
   },
   beforeMount() {
     if (process.client) {
+      const foo = 'bar'
+    }
+  },
+  beforeDestroy() {
+    if (process.browser) {
       const foo = 'bar'
     }
   }
@@ -37,6 +42,9 @@ export default {
     const foo = 'bar'
   },
   beforeMount() {
+    const foo = 'bar'
+  },
+  beforeDestroy() {
     const foo = 'bar'
   }
 }

--- a/lib/rules/__tests__/no-env-in-hooks.test.js
+++ b/lib/rules/__tests__/no-env-in-hooks.test.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview disallow `process.server/process.client` in `Vue Lifecycle Hooks`
+ * @fileoverview disallow `process.server`/`process.client`/`process.browser` in `Vue Lifecycle Hooks`
  * @author Xin Du <clark.duxin@gmail.com>
  */
 'use strict'
@@ -34,6 +34,9 @@ ruleTester.run('no-env-in-hooks', rule, {
           },
           beforeMount() {
             const foo = 'bar'
+          },
+          beforeDestroy() {
+            const foo = 'bar'
           }
         }
       `,
@@ -55,6 +58,11 @@ ruleTester.run('no-env-in-hooks', rule, {
             if(process.client) {
               const foo = 'bar'
             }
+          },
+          beforeDestroy() {
+            if(process.browser) {
+              const foo = 'bar'
+            }
           }
         }
       `,
@@ -63,6 +71,9 @@ ruleTester.run('no-env-in-hooks', rule, {
         type: 'MemberExpression'
       }, {
         message: 'Unexpected process.client in beforeMount.',
+        type: 'MemberExpression'
+      }, {
+        message: 'Unexpected process.browser in beforeDestroy.',
         type: 'MemberExpression'
       }],
       parserOptions
@@ -80,6 +91,11 @@ ruleTester.run('no-env-in-hooks', rule, {
             if(process['server']) {
               const foo = 'bar'
             }
+          },
+          beforeDestroy() {
+            if(process['browser']) {
+              const foo = 'bar'
+            }
           }
         }
       `,
@@ -88,6 +104,9 @@ ruleTester.run('no-env-in-hooks', rule, {
         type: 'MemberExpression'
       }, {
         message: 'Unexpected process.server in beforeMount.',
+        type: 'MemberExpression'
+      }, {
+        message: 'Unexpected process.browser in beforeDestroy.',
         type: 'MemberExpression'
       }],
       parserOptions

--- a/lib/rules/no-env-in-hooks.js
+++ b/lib/rules/no-env-in-hooks.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview disallow process.server and process.client in the following lifecycle hooks: beforeMount, mounted, beforeUpdate, updated, activated, deactivated, beforeDestroy and destroyed
+ * @fileoverview disallow process.server, process.client and process.browser in the following lifecycle hooks: beforeMount, mounted, beforeUpdate, updated, activated, deactivated, beforeDestroy and destroyed
  * @author Xin Du <clark.duxin@gmail.com>
  */
 'use strict'
@@ -27,7 +27,7 @@ module.exports = {
     const forbiddenNodes = []
     const options = context.options[0] || {}
 
-    const ENV = ['server', 'client']
+    const ENV = ['server', 'client', 'browser']
     const HOOKS = new Set(['beforeMount', 'mounted', 'beforeUpdate', 'updated', 'activated', 'deactivated', 'beforeDestroy', 'destroyed'].concat(options.methods || []))
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
`process.browser` is also set to `true` in client builds: https://github.com/nuxt/nuxt.js/blob/v2.14.12/packages/webpack/src/config/client.js#L46