### PR TITLE
feat(rule): add no-unresolved-middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ Include all the below rules, as well as all priority rules in above categories, 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 |  | [nuxt/require-func-head](./docs/rules/require-func-head.md) | Enforce `head` property in component to be a function. |
+|  | [nuxt/no-unresolved-middleware](./docs/rules/no-unresolved-middleware.md) | Checks for the presence of Nuxt.js middleware. |

--- a/docs/rules/no-unresolved-middleware.md
+++ b/docs/rules/no-unresolved-middleware.md
@@ -1,0 +1,62 @@
+# nuxt/no-unresolved-middleware
+
+> Checks for the presence of Nuxt.js middleware.
+
+## Rule Details
+
+This rule outputs an error if a file that does not exist in the `middleware` directory is specified.
+
+Examples of **incorrect** code for this rule:
+
+```
+middleware
+  └─ middleware-sample.js
+```
+
+```vue
+// pages/home.vue
+<script lang="ts">
+export default defineComponent({
+  middleware: 'sample', // sample is not found.
+});
+</script>
+```
+
+Examples of **correct** code for this rule:
+
+```
+middleware
+  └─ middleware-sample.js
+```
+
+```vue
+// pages/home.vue
+<script lang="ts">
+export default defineComponent({
+  middleware: 'middleware-sample',
+});
+</script>
+```
+
+## Options
+
+`srcDir`: Define the source directory of your Nuxt application.
+
+```json
+{
+  "plugins": ["nuxt"],
+  "rules": {
+    "nuxt/no-unresolved-middleware": [
+      "error",
+      {
+        "srcDir": "src"
+      }
+    ]
+  }
+}
+```
+
+## :mag: Implementation
+
+- [Rule source](../../lib/rules/no-unresolved-middleware.js)
+- [Test source](../../lib/rules/__tests__/no-unresolved-middleware.test.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ module.exports = {
     'no-this-in-fetch-data': require('./rules/no-this-in-fetch-data'),
     'no-timing-in-fetch-data': require('./rules/no-timing-in-fetch-data'),
     'no-cjs-in-config': require('./rules/no-cjs-in-config'),
-    'require-func-head': require('./rules/require-func-head')
+    'require-func-head': require('./rules/require-func-head'),
+    'no-unresolved-middleware': require('./rules/no-unresolved-middleware')
   },
   configs: {
     base: require('./configs/base'),

--- a/lib/rules/__tests__/no-unresolved-middleware.test.js
+++ b/lib/rules/__tests__/no-unresolved-middleware.test.js
@@ -40,6 +40,38 @@ ruleTester.run('no-unresolved-middleware', rule, {
         middleware: 'test'
       })
       </script>`,
+      options: [{ srcDir: 'lib/rules/mocks' }],
+      errors: [
+        {
+          messageId: 'noUnresolvedMiddleware'
+        }
+      ]
+    },
+    {
+      code: `
+      <script>
+      export default defineComponent({
+        middleware: ['test', 'test2']
+      })
+      </script>`,
+      options: [{ srcDir: 'lib/rules/mocks' }],
+      errors: [
+        {
+          messageId: 'noUnresolvedMiddleware'
+        },
+        {
+          messageId: 'noUnresolvedMiddleware'
+        }
+      ]
+    },
+    {
+      code: `
+      <script>
+      export default defineComponent({
+        middleware: ['test', 'middleware-sample']
+      })
+      </script>`,
+      options: [{ srcDir: 'lib/rules/mocks' }],
       errors: [
         {
           messageId: 'noUnresolvedMiddleware'

--- a/lib/rules/__tests__/no-unresolved-middleware.test.js
+++ b/lib/rules/__tests__/no-unresolved-middleware.test.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview disallow `setTimeout/setInterval` in `asyncData/fetch`
+ * @author Xin Du <clark.duxin@gmail.com>
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../no-unresolved-middleware')
+
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+})
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+ruleTester.run('no-unresolved-middleware', rule, {
+  valid: [
+    {
+      code: `
+    <script>
+    export default defineComponent({
+      middleware: 'middleware-sample'
+    })
+    </script>`,
+      options: [{ srcDir: 'lib/rules/mocks' }]
+    }
+  ],
+  invalid: [
+    {
+      code: `
+      <script>
+      export default defineComponent({
+        middleware: 'test'
+      })
+      </script>`,
+      errors: [
+        {
+          messageId: 'noUnresolvedMiddleware'
+        }
+      ]
+    }
+  ]
+})

--- a/lib/rules/mocks/middleware/middleware-sample.js
+++ b/lib/rules/mocks/middleware/middleware-sample.js
@@ -1,0 +1,5 @@
+export default function (context) {
+  context.userAgent = process.server
+    ? context.req.headers['user-agent']
+    : navigator.userAgent
+}

--- a/lib/rules/no-unresolved-middleware.js
+++ b/lib/rules/no-unresolved-middleware.js
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview disallow `setTimeout/setInterval` in `asyncData/fetch`
+ * @author Xin Du <clark.duxin@gmail.com>
+ */
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Check for the presence of middleware.',
+      recommended: 'error',
+      category: 'recommended'
+    },
+    messages: {
+      noUnresolvedMiddleware: '{{ fileName }} is not found.'
+    },
+    schema: [
+      {
+        type: 'object'
+      }
+    ]
+  },
+
+  create: (context) => {
+    const srcDir = context.options[0]?.srcDir ?? '/'
+
+    return {
+      ExportDefaultDeclaration (node) {
+        if (!context.getCwd) {
+          return
+        }
+        const middlewareDir = path.join(context.getCwd(), srcDir, 'middleware')
+
+        if (node.declaration.type !== 'CallExpression') {
+          return
+        }
+
+        if (node.declaration.callee.type !== 'Identifier') {
+          return
+        }
+
+        const arg = node.declaration.arguments[0]
+
+        if (arg.type !== 'ObjectExpression') {
+          return
+        }
+
+        const properties = arg.properties
+
+        const middlewareNode = properties.find(
+          (x) =>
+            x.type === 'Property' &&
+            x.key.type === 'Identifier' &&
+            x.key.name === 'middleware'
+        )
+
+        if (!middlewareNode) {
+          return
+        }
+
+        if (middlewareNode.type !== 'Property') {
+          return
+        }
+
+        if (middlewareNode.value.type !== 'Literal') {
+          return
+        }
+
+        const middlewareFile = middlewareNode.value.value?.toString()
+
+        if (!middlewareFile) {
+          return
+        }
+
+        const isJsExist = fs.existsSync(
+          path.resolve(middlewareDir, `${middlewareFile}.js`)
+        )
+
+        const isTsExist = fs.existsSync(
+          path.resolve(middlewareDir, `${middlewareFile}.ts`)
+        )
+
+        if (isJsExist || isTsExist) {
+          return
+        }
+
+        context.report({
+          node,
+          messageId: 'noUnresolvedMiddleware',
+          data: {
+            fileName: middlewareFile
+          }
+        })
+      }
+    }
+  }
+}

--- a/lib/rules/no-unresolved-middleware.js
+++ b/lib/rules/no-unresolved-middleware.js
@@ -69,35 +69,66 @@ module.exports = {
           return
         }
 
-        if (middlewareNode.value.type !== 'Literal') {
+        if (
+          middlewareNode.value.type !== 'Literal' &&
+          middlewareNode.value.type !== 'ArrayExpression'
+        ) {
           return
         }
 
-        const middlewareFile = middlewareNode.value.value?.toString()
+        const report = (middlewareFile) => {
+          const isJsExist = fs.existsSync(
+            path.resolve(middlewareDir, middlewareFile + '.js')
+          )
 
-        if (!middlewareFile) {
-          return
-        }
+          const isTsExist = fs.existsSync(
+            path.resolve(middlewareDir, middlewareFile + '.ts')
+          )
 
-        const isJsExist = fs.existsSync(
-          path.resolve(middlewareDir, `${middlewareFile}.js`)
-        )
+          const isFileExist = isJsExist || isTsExist
 
-        const isTsExist = fs.existsSync(
-          path.resolve(middlewareDir, `${middlewareFile}.ts`)
-        )
-
-        if (isJsExist || isTsExist) {
-          return
-        }
-
-        context.report({
-          node,
-          messageId: 'noUnresolvedMiddleware',
-          data: {
-            fileName: middlewareFile
+          if (isFileExist) {
+            return
           }
-        })
+
+          context.report({
+            node,
+            messageId: 'noUnresolvedMiddleware',
+            data: {
+              fileName: middlewareFile
+            }
+          })
+        }
+
+        if (middlewareNode.value.type === 'Literal') {
+          const middlewareFile = middlewareNode.value.value?.toString()
+
+          if (!middlewareFile) {
+            return
+          }
+
+          report(middlewareFile)
+        } else if (middlewareNode.value.type === 'ArrayExpression') {
+          const middlewareFiles = middlewareNode.value.elements
+
+          if (!middlewareFiles) {
+            return
+          }
+
+          middlewareFiles.forEach((x) => {
+            if (x.type !== 'Literal') {
+              return
+            }
+
+            const middlewareFile = x.value?.toString()
+
+            if (!middlewareFile) {
+              return
+            }
+
+            report(middlewareFile)
+          })
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
We had set up a file that did not exist in nuxt's middleware and released the application without realizing it.
I thought it was possible to prevent this by ESLint, so I created a rule.

I believe this rule will help developers who use nuxt.
I released the package myself, but I thought it looked better to have it in this repository, so I implemented it. (I will deprecate my repository if it is adopted)
https://github.com/wattanx/eslint-plugin-nuxt-middleware

Thank you in advance for your consideration.

## nuxt/no-unresolved-middleware

> Checks for the presence of Nuxt.js middleware.

## Rule Details

This rule outputs an error if a file that does not exist in the `middleware` directory is specified.

Examples of **incorrect** code for this rule:

```
middleware
  └─ middleware-sample.js
```

```vue
// pages/home.vue
<script lang="ts">
export default defineComponent({
  middleware: 'sample', // sample is not found.
});
</script>
```

Examples of **correct** code for this rule:

```
middleware
  └─ middleware-sample.js
```

```vue
// pages/home.vue
<script lang="ts">
export default defineComponent({
  middleware: 'middleware-sample',
});
</script>
```

## Options

`srcDir`: Define the source directory of your Nuxt application.

```json
{
  "plugins": ["nuxt"],
  "rules": {
    "nuxt/no-unresolved-middleware": [
      "error",
      {
        "srcDir": "src"
      }
    ]
  }
}
```
